### PR TITLE
Add an "Insurance" category

### DIFF
--- a/data/categories.json
+++ b/data/categories.json
@@ -86,7 +86,7 @@
   },
   "insurance": {
     "title": "Insurance",
-    "icon": "&#xF5FC;"
+    "icon": "&#xF467;"
   },
   "investing": {
     "title": "Investing",

--- a/data/categories.json
+++ b/data/categories.json
@@ -84,6 +84,10 @@
     "title": "Identity Management",
     "icon": "&#xF4D3;"
   },
+  "insurance": {
+    "title": "Insurance",
+    "icon": "&#xF5FC;"
+  },
   "investing": {
     "title": "Investing",
     "icon": "&#xF3F2;"


### PR DESCRIPTION
As proposed in [2factorauth/twofactorauth#8098](https://github.com/2factorauth/twofactorauth/pull/8098#issuecomment-2172082569), this is a new category for insurance. It's currently using the [filled umbrella icon](https://icons.getbootstrap.com/icons/umbrella-fill) from Bootstrap Icons.