### PR TITLE
Handle CF Page build errors

### DIFF
--- a/functions/redirect.js
+++ b/functions/redirect.js
@@ -1,13 +1,29 @@
-export async function onRequest({env, request}) {
-  const base = env.base || 'https://2fa.pages.dev/'
-  const country = request.cf?.country.toLowerCase() || "int";
-  let uri = `${base}${country}`
-  const res = await fetch(uri, {
-    cf: {
-      cacheTtl: 86400, cacheEverything: true
-    }
-  })
-  if (res.status !== 200) uri = `${base}/int`
+export async function onRequestGet({request}) {
+  const url = new URL(request.url);
+  const base = `${url.protocol}//${url.hostname}/`;
+  const redirectStatus = 302;
+  try {
+    const country = request.cf?.country?.toLowerCase() || 'int';
+    let uri = `${base}${country}/`;
 
-  return Response.redirect(uri, 302);
+    const res = await fetch(uri, {
+      cf: {
+        cacheTtlByStatus: {
+          '200': 60 * 60 * 24 * 7, // Cache request 1 week
+          '404': 60 * 60 * 24, // Cache request 1 day
+        },
+      },
+    });
+
+    // Redirect to /int/ if that page works
+    if (res.status !== 200) {
+      const int = await fetch(`${base}int/`);
+      uri = int.status === 200 ? `${base}/int/`:`${base}/503/`;
+    }
+
+    return Response.redirect(uri, redirectStatus);
+  } catch (e) {
+    console.error(e);
+    return Response.redirect(`${base}/502/`, redirectStatus);
+  }
 }

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<main>
+  <h1 class="display-1">404</h1>
+  <p class="note">Not Found</p>
+</main>
+<style>
+  main {
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+  }
+
+  .note {
+    font-size: 2em;
+  }
+</style>
+{{ end }}

--- a/layouts/502.html
+++ b/layouts/502.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<main>
+  <h1 class="display-1">502</h1>
+  <p class="note">Bad Gateway</p>
+</main>
+<style>
+  main {
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+  }
+
+  .note {
+    font-size: 2em;
+  }
+</style>
+{{ end }}

--- a/layouts/503.html
+++ b/layouts/503.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+<main>
+  <h1 class="display-1">503</h1>
+  <p class="note">Service Unavailable</p>
+</main>
+<style>
+  main {
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+  }
+
+  .note {
+    font-size: 2em;
+  }
+</style>
+{{ end }}


### PR DESCRIPTION
When the 2fa.directory build failed last week, the redirect script sent users in an infinite loop.
To stop this from happening again, I reworked the redirect script so that the logic now is the following:
1. If the user's origin region exists on the 2fa.directory, redirect to that region.
2. If `2fa.directory/int/` returns 200, redirect to `/int/`.
3. If all else fails, return the static page `/503/`. (HTTP 503 - Service Unavailable)
4. If the redirect script fails, return the static page `/502/`. (HTTP 502 - Bad Gateway)

I also created a 404 page and increased the caching ttl for existing regions.