### PR TITLE
Rename Twitter to X

### DIFF
--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -174,7 +174,7 @@
         }
 
         &.twitter:after {
-          content: 'On Twitter';
+          content: 'On X (Twitter)';
         }
 
         &.facebook:after {
@@ -215,10 +215,10 @@
     }
 
     &.twitter {
-      background: #1da1f2;
+      background: #000;
 
       &:before {
-        content: '\F5EF';
+        content: '\F8DB';
       }
     }
 

--- a/layouts/partials/base.stylesheet.html
+++ b/layouts/partials/base.stylesheet.html
@@ -28,7 +28,6 @@
   {{ $styles = $styles | append "error" }}
 {{ end }}
 
-
 {{ $scss := slice }}
 {{ range $style := $styles }}
   {{ $scss = $scss | append (resources.Get ($style | printf "css/%s.scss")) }}


### PR DESCRIPTION
Rename Twitter to X (Twitter)

As Apartheid Clyde changed the branding from the teal bird to the black X, I also changed the color of the tweet button to black, which seems to be the brand color.

New button design:
![image](https://github.com/user-attachments/assets/2cb61eeb-da97-4ade-b164-868e1ab51305)
