### PR TITLE
Speed up redirect function

### DIFF
--- a/functions/redirect.js
+++ b/functions/redirect.js
@@ -1,26 +1,23 @@
 export async function onRequestGet({ request }) {
   const url = new URL(request.url);
   const base = `${url.protocol}//${url.hostname}/`;
-  const redirectStatus = 302;
+  const redirectStatus = 301;
+  const api = 'https://api.2fa.directory/frontend/v1/';
 
   try {
-    const country = request.cf?.country?.toLowerCase() || "int";
-    let uri = `${base}${country}/`;
-
-    const res = await fetch(uri, {
+    const country = request.cf?.country?.toLowerCase();
+    const res = await fetch(`${api}${country}/categories.json`, {
+      method: 'HEAD',
+      cache: 'force-cache',
       cf: {
         cacheTtlByStatus: {
-          "200": 60 * 60 * 24 * 7, // Cache request 1 week
-          "404": 60 * 60 * 24, // Cache request 1 day
+          "200": 60 * 60 * 24 * 14, // Cache request 2 weeks
+          "404": 60 * 60 * 24 * 7,  // Cache request 1 week
         },
-      },
+      }
     });
 
-    // Redirect to /int/ if that page works
-    if (res.status !== 200) {
-      const int = await fetch(`${base}int/`);
-      uri = int.status === 200 ? `${base}/int/` : `${base}/503/`;
-    }
+    let uri = res.status !== 200 ? `${base}${country}/` : `${base}/int/`
 
     const params = url.searchParams.toString();
     if (params) uri += `?${params}`;


### PR DESCRIPTION
Made some changes to the redirect script.

* Switched from validating whether the region exists based on GET requests to the frontend to now validate against the API using a HEAD request which should require less data.
* Updated the cache ttl from 1 week / 1 day  to 2 weeks / 1 week.
* Removed the 503 redirect as if the frontend doesn't work, the 503 page most likely won't work either.
* Changed redirect status from 302 to 301 as it would be very rare that a device changes region.
