### PR TITLE
Add info icon back

### DIFF
--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -154,6 +154,13 @@
       &.software {
         grid-area: 1 / 7 / 2 / 8;
       }
+
+      .icon-info {
+        &:before{
+          content: '\e88e';
+          font-family: 'Material Symbols Outlined';
+        }
+      }
     }
 
     .contact {

--- a/assets/css/table.scss
+++ b/assets/css/table.scss
@@ -157,7 +157,7 @@
 
       .icon-info {
         &:before{
-          content: '\e88e';
+          content: '\E88E';
           font-family: 'Material Symbols Outlined';
         }
       }

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -53,6 +53,7 @@ const icons = [
   'group',
   'hard_drive',
   'id_card',
+  'info',
   'language',
   'mail',
   'markunread_mailbox',

--- a/src/components/table.jsx
+++ b/src/components/table.jsx
@@ -143,8 +143,8 @@ function Methods({ methods, customSoftware, customHardware }) {
  */
 function CustomMethods({ type, methods }) {
   return methods.length !== 0 ?
-    <i class={`bi bi-info-circle custom-${type}-popover`} data-bs-content={methods.map((method) => `<li>${method}</li>`).join("")} data-bs-toggle="popover"></i>
-    : <i class="bi bi-info-circle" title={`Requires proprietary ${type === "hardware" ? "hardware token" : "app/software"}`}></i>;
+    <span class={`icon-info custom-${type}-popover`} data-bs-content={methods.map((method) => `<li>${method}</li>`).join("")} data-bs-toggle="popover"></span>
+    : <span class="icon-info" title={`Requires proprietary ${type === "hardware" ? "hardware token" : "app/software"}`}></span>;
 }
 
 // Intialize popovers


### PR DESCRIPTION
The info icon, used by the custom methods, did not get ported over with the switch to Material Symbols.