### PR TITLE
Fix social notices

### DIFF
--- a/src/components/table.jsx
+++ b/src/components/table.jsx
@@ -180,8 +180,8 @@ function Contact({ contact }) {
   return (
     <div aria-label="2FA not supported" className="contact">
       {contact.twitter && (<button className="contact-btn twitter" onClick={() => socialMediaNotice("tweet", lang, contact.twitter)}></button>)}
-      {contact.facebook && (<button className="contact-btn facebook" onClick={() => socialMediaNotice("facebook", lang, contact.twitter)}></button>)}
-      {contact.email && (<button className="contact-btn email" onClick={() => socialMediaNotice("email", lang, contact.twitter)}></button>)}
+      {contact.facebook && (<button className="contact-btn facebook" onClick={() => socialMediaNotice("facebook", lang, contact.facebook)}></button>)}
+      {contact.email && (<button className="contact-btn email" onClick={() => socialMediaNotice("email", lang, contact.email)}></button>)}
       {contact.form && (<button className="contact-btn form" onClick={() => window.open(contact.form, "_blank")}></button>)}
     </div>
   );

--- a/src/components/table.jsx
+++ b/src/components/table.jsx
@@ -85,6 +85,12 @@ function Entry({ name, data }) {
   );
 }
 
+const mfaPopoverConfig = {
+  html: true,
+  sanitize: false,
+  trigger: "hover focus"
+};
+
 function Methods({ methods, customSoftware, customHardware }) {
   useEffect(() => {
     [...document.querySelectorAll('.note')].map((el) => new Popover(el, {
@@ -148,13 +154,6 @@ function CustomMethods({ type, methods }) {
     <span class={`icon-info custom-${type}-popover`} data-bs-content={methods.map((method) => `<li>${method}</li>`).join("")} data-bs-toggle="popover"></span>
     : <span class="icon-info" title={`Requires proprietary ${type === "hardware" ? "hardware token" : "app/software"}`}></span>;
 }
-
-// Intialize popovers
-const mfaPopoverConfig = {
-  html: true,
-  sanitize: false,
-  trigger: "hover focus"
-};
 
 // Social Media Notices
 /**


### PR DESCRIPTION
The Facebook and email buttons were using the Twitter handle of the service.