### PR TITLE
Fix missing category icons

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,4 +3,4 @@
   X-Frame-Options: DENY
   Access-Control-Allow-Origin: none
   Permissions-Policy: geolocation=(),microphone=(),camera=(),autoplay=(),payment=(),speaker=()fullscreen=(self)
-  Content-Security-Policy: script-src 'self' https://cdnjs.cloudflare.com; script-src-attr 'unsafe-hashes' 'sha256-1jAmyYXcRq6zFldLe/GCgIDJBiOONdXjTLgEFMDnDSM='; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com/css2; img-src 'self' https://api.2fa.directory https://cdnjs.cloudflare.com/ajax/libs/flag-icons/; font-src https://cdnjs.cloudflare.com https://fonts.gstatic.com/icon/font; report-uri https://2factorauth.report-uri.com/r/d/csp/enforce;
+  Content-Security-Policy: script-src 'self' https://cdnjs.cloudflare.com; script-src-attr 'unsafe-hashes' 'sha256-1jAmyYXcRq6zFldLe/GCgIDJBiOONdXjTLgEFMDnDSM='; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com/css2; img-src 'self' https://api.2fa.directory https://cdnjs.cloudflare.com/ajax/libs/flag-icons/; font-src https://cdnjs.cloudflare.com https://fonts.gstatic.com/l/font; report-uri https://2factorauth.report-uri.com/r/d/csp/enforce;


### PR DESCRIPTION
Resolves 2factorauth/twofactorauth#8541

Google updated the icon font url to be `/l/font` instead of `/icon/font`. Our CSP only allowed the old one.